### PR TITLE
Fix/typos

### DIFF
--- a/02-building-the-weather-app-core.md
+++ b/02-building-the-weather-app-core.md
@@ -14,7 +14,7 @@
 
 1. Create a Basic Layout
 
-   - Open the Copilot **Chat View** (`Ctrl+Alt+I` or `Cmd+Alt+I`)
+   - Open the Copilot **Chat View** (`Ctrl+Alt+I` or `Ctrl+Cmd+I`)
    - Prompt Copilot with a **workspace** query like the following:
 
      ```md

--- a/02-building-the-weather-app-core.md
+++ b/02-building-the-weather-app-core.md
@@ -39,7 +39,7 @@
    - Add the API key:
 
      ```env
-     REACT_APP_WEATHER_API_KEY=your_api_key_here
+     VITE_WEATHER_API_KEY=your_api_key_here
      ```
 
 3. Fetch Weather Data

--- a/README.md
+++ b/README.md
@@ -22,7 +22,7 @@ By the end of this workshop, participants will:
 ## Interacting with GitHub Copilot
 Throughout the lab tasks, you will need to interact with Copilot. There are several methods of interacting, including:
 *   Inline Chat (`Ctrl+I` or `Cmd+I`)
-*   Chat View (`Ctrl+Alt+I` or `Cmd+Alt+I`)
+*   Chat View (`Ctrl+Alt+I` or `Ctrl+Cmd+I`)
 *   Inline suggestion (code completion)
 
 It is recommended that you try each method as you progress through this lab, as each method has unique strengths. While we often suggest a particular method of interaction, that may not be the only way to complete a lab task, so you're invited to try other methods too.


### PR DESCRIPTION
### Summary of changes:

- Fixed a couple of occurrences where, to open the Chat View on MacOs, the tutorial suggests to use the `Alt` key
- `REACT_APP_*` variables in .env files are only accessible in react apps created with [Create React App (CRA)](https://create-react-app.dev/). Given the tutorial suggests to initialise the repo with [Vite](https://vite.dev/), the variables have to start with the `VITE_*` convention to be accessible